### PR TITLE
Change github url in comments to githubusercontent.com

### DIFF
--- a/hssqlppp/src/Database/HsSqlPpp/Syntax.lhs
+++ b/hssqlppp/src/Database/HsSqlPpp/Syntax.lhs
@@ -6,7 +6,7 @@
 >      the seemingly pointless type synonyms below, they are an
 >      artefact of using UUAGC. You can see labels for the fields by
 >      looking at the ag source here:
->      <https://github.com/JakeWheat/hssqlppp/blob/master/src/Database/HsSqlPpp/Internals/AstInternal.ag>
+>      <https://raw.githubusercontent.com/JakeWheat/hssqlppp/master/hssqlppp/src/Database/HsSqlPpp/Internals/AstInternal.ag>
 >      -}
 >
 > module Database.HsSqlPpp.Syntax


### PR DESCRIPTION
There is a broken link in the description on [hackage](https://hackage.haskell.org/package/hssqlppp-0.6.0/docs/Database-HsSqlPpp-Syntax.html). I guess it is related to [this issue](https://developer.github.com/changes/2014-04-25-user-content-security/). I changed it to point to [githubusercontent](https://raw.githubusercontent.com/JakeWheat/hssqlppp/master/hssqlppp/src/Database/HsSqlPpp/Internals/AstInternal.ag).

There is also a broken link in /Internals/AstInternal.ag to devel.txt.html  but I couldn't find a current file.