### PR TITLE
Pass Tref environment to 'where' sub-expression of 'delete from' statement when typechecking.

### DIFF
--- a/hssqlppp/src/Database/HsSqlPpp/Internals/TypeChecking/Boilerplate.ag
+++ b/hssqlppp/src/Database/HsSqlPpp/Internals/TypeChecking/Boilerplate.ag
@@ -169,7 +169,6 @@ sem Statement | CreateView ann.tpe = Left []
 sem Statement | CreateView expr.outerDownEnv = Nothing
 sem Statement | CreateView name.tpe = Left []
 sem Statement | Delete table.tpe = Left []
-sem Statement | Delete whr.downEnv = E.emptyEnvironment
 sem Statement | DropFunction ann.tpe = Left []
 sem Statement | DropTrigger tbl.tpe = Left []
 sem Statement | ExecStatement args.downEnv = E.emptyEnvironment

--- a/hssqlppp/src/Database/HsSqlPpp/Internals/TypeChecking/Updates.ag
+++ b/hssqlppp/src/Database/HsSqlPpp/Internals/TypeChecking/Updates.ag
@@ -15,8 +15,15 @@ copyfrom
 
 
 sem Statement
-  | Insert Update Delete CopyFrom CopyTo Truncate
+  | Insert Update CopyFrom CopyTo Truncate
     ann.tpe = Left []
+
+  | Delete
+    loc.eEnv :: {Either [TypeError] Environment}
+    loc.eEnv = E.envCreateTrefEnvironment @lhs.cat (nameComponents @table.originalTree)
+    ann.tpe = either Left (Right . mkTypeExtraNN . TrefType)
+              (@loc.eEnv >>= E.envExpandStar Nothing)
+    whr.downEnv = either (const E.brokeEnvironment) id @loc.eEnv
 
   | Insert
     -- find the table and column names


### PR DESCRIPTION
I just copied the Tref branch of TableRefs.ag to the Delete branch of Updates.ag so that the 'where' sub-expression would have the columns of the table in the environment. Currently an empty environment was used so 'delete from' statements always failed to typecheck. I'm not sure if this is the best way to do it but the current code does not work.